### PR TITLE
Add proxy-autoswitch script and NetworkManager dispatcher for automatic proxy toggling

### DIFF
--- a/live-injection-src/sysroot/ventoy/scripts/install-proxy-autoswitch.sh
+++ b/live-injection-src/sysroot/ventoy/scripts/install-proxy-autoswitch.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+install -d -m 0755 /usr/local/bin
+install -d -m 0755 /etc/NetworkManager/dispatcher.d
+
+cat > /usr/local/bin/proxy-autoswitch.sh <<'AUTOSWITCH'
+#!/usr/bin/env bash
+set -euo pipefail
+
 PROXY_URL="http://172.30.11.253:8080"
 NO_PROXY_LIST="localhost,127.0.0.1,::1,.cnieg.fr,.iegp.edfgdf.fr"
+APT_CONF="/etc/apt/apt.conf.d/90proxy"
 
 IPS="$(ip -4 -o addr show scope global | awk '{print $4}' | cut -d/ -f1 | tr '\n' ' ' || true)"
 
@@ -17,23 +25,55 @@ for ip in $IPS; do
 done
 
 if [ "$need_proxy" -eq 1 ]; then
+  echo "[proxy] enabling proxy"
+
   mkdir -p /etc/apt/apt.conf.d
-  cat > /etc/apt/apt.conf.d/90proxy <<EOF
+  cat > "$APT_CONF" <<APT_EOF
 Acquire::http::Proxy "$PROXY_URL";
 Acquire::https::Proxy "$PROXY_URL";
 Acquire::Retries "2";
 Acquire::http::Timeout "20";
 Acquire::https::Timeout "20";
-EOF
+APT_EOF
 
-  cat > /etc/environment <<EOF
+  cat > /etc/environment <<ENV_EOF
 http_proxy=$PROXY_URL
 https_proxy=$PROXY_URL
 HTTP_PROXY=$PROXY_URL
 HTTPS_PROXY=$PROXY_URL
 no_proxy=$NO_PROXY_LIST
 NO_PROXY=$NO_PROXY_LIST
-EOF
+ENV_EOF
 else
-  rm -f /etc/apt/apt.conf.d/90proxy || true
+  echo "[proxy] disabling proxy"
+  rm -f "$APT_CONF"
+
+  cat > /etc/environment <<'ENV_EOF'
+http_proxy=
+https_proxy=
+HTTP_PROXY=
+HTTPS_PROXY=
+no_proxy=
+NO_PROXY=
+ENV_EOF
 fi
+AUTOSWITCH
+
+chmod 0755 /usr/local/bin/proxy-autoswitch.sh
+
+cat > /etc/NetworkManager/dispatcher.d/90-proxy <<'DISPATCHER'
+#!/usr/bin/env bash
+
+INTERFACE="$1"
+STATUS="$2"
+
+case "$STATUS" in
+  up|dhcp4-change|connectivity-change)
+    /usr/local/bin/proxy-autoswitch.sh
+    ;;
+esac
+DISPATCHER
+
+chmod 0755 /etc/NetworkManager/dispatcher.d/90-proxy
+
+/usr/local/bin/proxy-autoswitch.sh || true


### PR DESCRIPTION
### Motivation

- Provide automatic enabling/disabling of HTTP/HTTPS/apt proxies when the host is on specific internal IP ranges (172.30.* or 172.31.*).
- Ensure system-wide proxy environment variables and APT configuration are set consistently when a proxy is required and cleared otherwise.
- Trigger proxy logic on network events so settings follow interface connectivity changes.

### Description

- Create ` /usr/local/bin/proxy-autoswitch.sh` which detects IPv4 addresses, determines if a proxy is needed, writes `/etc/apt/apt.conf.d/90proxy` and `/etc/environment` when enabling the proxy, and clears those settings when disabling the proxy, with small log echoes for enable/disable actions.
- Ensure install paths exist with `install -d -m 0755` for `/usr/local/bin` and `/etc/NetworkManager/dispatcher.d` and set executable permissions with `chmod 0755` for the new scripts.
- Add a NetworkManager dispatcher script at `/etc/NetworkManager/dispatcher.d/90-proxy` that runs the autoswitch script on `up`, `dhcp4-change`, and `connectivity-change` events.
- Run the autoswitch script once at the end of the installation script with `/usr/local/bin/proxy-autoswitch.sh || true` to apply initial state.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cecc8b921c832b9f7451464b3bcb58)