### PR TITLE
hardening: fail fast on boot-critical steps (grub/initramfs)

### DIFF
--- a/live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh
+++ b/live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh
@@ -1,7 +1,26 @@
 #!/usr/bin/env bash
-set -euxo pipefail
+set -euo pipefail
 
 exec > /target/root/configure-btrfs-root-at.log 2>&1
+
+
+log() {
+  echo "[configure-btrfs-root-at] $*"
+}
+
+run_critical_step() {
+  local step_name="$1"
+  shift
+
+  log "START critical step: ${step_name}"
+  if "$@"; then
+    log "DONE critical step: ${step_name}"
+  else
+    local exit_code=$?
+    log "ERROR critical step failed: ${step_name} (exit=${exit_code})"
+    exit "$exit_code"
+  fi
+}
 
 TARGET="/target"
 TOP="/mnt/btrfs-top"
@@ -76,8 +95,8 @@ mount --bind /dev  "$TOP/@/dev"
 mount --bind /proc "$TOP/@/proc"
 mount --bind /sys  "$TOP/@/sys"
 
-chroot "$TOP/@" update-grub || true
-chroot "$TOP/@" update-initramfs -u -k all || true
+run_critical_step "update-grub" chroot "$TOP/@" update-grub
+run_critical_step "update-initramfs -u -k all" chroot "$TOP/@" update-initramfs -u -k all
 
 umount "$TOP/@/dev" || true
 umount "$TOP/@/proc" || true

--- a/live-injection-src/sysroot/ventoy/scripts/configure-system-optimizations.sh
+++ b/live-injection-src/sysroot/ventoy/scripts/configure-system-optimizations.sh
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+
+log() {
+  echo "[configure-system-optimizations] $*"
+}
+
+run_critical_step() {
+  local step_name="$1"
+  shift
+
+  log "START critical step: ${step_name}"
+  if "$@"; then
+    log "DONE critical step: ${step_name}"
+  else
+    local exit_code=$?
+    log "ERROR critical step failed: ${step_name} (exit=${exit_code})"
+    exit "$exit_code"
+  fi
+}
+
 if grep -q '^GRUB_TIMEOUT=' /etc/default/grub; then
   sed -i 's/^GRUB_TIMEOUT=.*/GRUB_TIMEOUT=1/' /etc/default/grub
 else
@@ -13,7 +32,7 @@ else
   echo 'GRUB_TIMEOUT_STYLE=hidden' >> /etc/default/grub
 fi
 
-update-grub || true
+run_critical_step "update-grub" update-grub
 
 touch /etc/cloud/cloud-init.disabled
 


### PR DESCRIPTION
### Motivation
- La refonte «ventoyisation» expose des chemins d’installation où des erreurs critiques de boot pouvaient être masquées par des `|| true` et rendre le système non bootable sans signaler d’échec. 
- L’objectif est de rendre bloquantes les étapes critiques de boot (grub / initramfs) et d’ajouter des logs explicites pour localiser les échecs. 
- Ce changement est minimal mais à fort impact sécurité/fiabilité pour éviter d’installer des systèmes non bootables silencieusement.

### Description
- Suppression du comportement permissif pour `update-grub` et `update-initramfs -u -k all` et remplacement par un wrapper `run_critical_step` qui logge `START/DONE/ERROR` et force une sortie non-zéro en cas d’échec. 
- Ajout d’une fonction `log()` et de la fonction `run_critical_step()` dans `live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh` et `live-injection-src/sysroot/ventoy/scripts/configure-system-optimizations.sh`. 
- Standardisation du mode strict shell avec `set -euo pipefail` (remplacement du `set -euxo pipefail` pour éviter l’assourdissant `-x` tout en conservant le comportement strict). 
- Les appels critiques sont maintenant `run_critical_step "update-grub" ...` et `run_critical_step "update-initramfs -u -k all" ...` afin d’assurer un code de sortie non-nul et un log clair en cas d’erreur.

### Testing
- Exécution de la vérification de syntaxe shell avec `bash -n live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh live-injection-src/sysroot/ventoy/scripts/configure-system-optimizations.sh` qui a réussi. 
- Recherche automatisée pour les usages permissifs résiduels avec `rg -n "update-grub\s*\|\|\s*true|update-initramfs\s+-u\s+-k\s+all\s*\|\|\s*true"` appliquée sur les scripts modifiés, qui n’a trouvé aucun match. 
- Les tests automatisés ci‑dessus ont passé avec succès.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cedc17a3f4832b9241b52cc318ce3d)