### PR TITLE
refactor: remove hardcoded block devices and use dynamic root/swap discovery

### DIFF
--- a/live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh
+++ b/live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/device-discovery.sh"
+
 exec > /target/root/configure-btrfs-root-at.log 2>&1
 
 
@@ -25,15 +28,30 @@ run_critical_step() {
 TARGET="/target"
 TOP="/mnt/btrfs-top"
 
-ROOT_DEV="$(findmnt -no SOURCE /target)"
-ROOT_UUID="$(findmnt -no UUID /target)"
+ROOT_DEV="$(detect_root_source /target)"
+ROOT_UUID="$(detect_root_uuid /target)"
 
 BOOT_DEV="$(findmnt -no SOURCE /target/boot)"
 EFI_DEV="$(findmnt -no SOURCE /target/boot/efi)"
 
 BOOT_UUID="$(blkid -s UUID -o value "$BOOT_DEV")"
 EFI_UUID="$(blkid -s UUID -o value "$EFI_DEV")"
-SWAP_UUID="$(blkid -s UUID -o value /dev/nvme0n1p3)"
+SWAP_UUID="$(detect_swap_uuid)"
+
+if [ -z "$ROOT_DEV" ] || [ ! -e "$ROOT_DEV" ]; then
+  fail_device_discovery "unable to resolve root device for /target"
+  exit 1
+fi
+
+if [ -z "$ROOT_UUID" ]; then
+  fail_device_discovery "unable to resolve root UUID for /target"
+  exit 1
+fi
+
+if [ "$SWAP_UUID" = "none" ] || [ -z "$SWAP_UUID" ]; then
+  fail_device_discovery "unable to resolve swap UUID; refusing to generate fstab"
+  exit 1
+fi
 
 mkdir -p "$TOP"
 mount -o subvolid=5 "$ROOT_DEV" "$TOP"

--- a/live-injection-src/sysroot/ventoy/scripts/configure-recovery-and-tpm.sh
+++ b/live-injection-src/sysroot/ventoy/scripts/configure-recovery-and-tpm.sh
@@ -1,7 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_PART="/dev/nvme0n1p4"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/device-discovery.sh"
+
+ROOT_PART="$(detect_root_partition /)"
+if [ -z "$ROOT_PART" ] || [ ! -b "$ROOT_PART" ]; then
+  fail_device_discovery "detected root partition is invalid: ${ROOT_PART:-<empty>}"
+  exit 1
+fi
 
 install -d -m 0700 /root/recovery
 umask 077

--- a/live-injection-src/sysroot/ventoy/scripts/lib/device-discovery.sh
+++ b/live-injection-src/sysroot/ventoy/scripts/lib/device-discovery.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+
+log_device_discovery() {
+  echo "[device-discovery] $*" >&2
+}
+
+fail_device_discovery() {
+  log_device_discovery "ERROR: $*"
+  return 1
+}
+
+resolve_device_spec() {
+  local spec="$1"
+
+  case "$spec" in
+    UUID=*)
+      blkid -U "${spec#UUID=}" 2>/dev/null || true
+      ;;
+    PARTUUID=*)
+      blkid -t "PARTUUID=${spec#PARTUUID=}" -o device 2>/dev/null | head -n1 || true
+      ;;
+    /dev/*)
+      readlink -f "$spec" 2>/dev/null || echo "$spec"
+      ;;
+    *)
+      echo "$spec"
+      ;;
+  esac
+}
+
+extract_root_from_cmdline() {
+  local root_spec
+  root_spec="$(sed -n 's/.*\broot=\([^[:space:]]\+\).*/\1/p' /proc/cmdline | head -n1)"
+
+  if [ -n "$root_spec" ]; then
+    resolve_device_spec "$root_spec"
+  fi
+}
+
+extract_root_from_fstab() {
+  local fstab_path="${1:-/etc/fstab}"
+
+  [ -f "$fstab_path" ] || return 0
+
+  awk '$1 !~ /^#/ && $2 == "/" { print $1; exit }' "$fstab_path" | {
+    read -r root_spec || true
+    [ -n "$root_spec" ] && resolve_device_spec "$root_spec"
+  }
+}
+
+detect_root_source() {
+  local mountpoint="${1:-/}"
+  local source=""
+
+  if source="$(findmnt -no SOURCE "$mountpoint" 2>/dev/null)" && [ -n "$source" ]; then
+    source="$(resolve_device_spec "$source")"
+    log_device_discovery "root source from findmnt(${mountpoint}): ${source}"
+    echo "$source"
+    return 0
+  fi
+
+  if source="$(extract_root_from_cmdline)" && [ -n "$source" ]; then
+    log_device_discovery "root source from /proc/cmdline: ${source}"
+    echo "$source"
+    return 0
+  fi
+
+  if source="$(extract_root_from_fstab)" && [ -n "$source" ]; then
+    log_device_discovery "root source from /etc/fstab: ${source}"
+    echo "$source"
+    return 0
+  fi
+
+  fail_device_discovery "unable to determine root source for mountpoint ${mountpoint}"
+}
+
+detect_root_partition() {
+  local mountpoint="${1:-/}"
+  local source pkname
+
+  source="$(detect_root_source "$mountpoint")" || return 1
+
+  if [[ "$source" == /dev/mapper/* || "$source" == /dev/dm-* ]]; then
+    pkname="$(lsblk -no PKNAME "$source" 2>/dev/null | head -n1)"
+    if [ -n "$pkname" ]; then
+      source="/dev/$pkname"
+      log_device_discovery "root partition under mapper: ${source}"
+      echo "$source"
+      return 0
+    fi
+  fi
+
+  log_device_discovery "root partition resolved directly: ${source}"
+  echo "$source"
+}
+
+detect_root_uuid() {
+  local mountpoint="${1:-/}"
+  local source root_uuid
+
+  source="$(detect_root_source "$mountpoint")" || return 1
+
+  root_uuid="$(blkid -s UUID -o value "$source" 2>/dev/null | head -n1 || true)"
+  if [ -n "$root_uuid" ]; then
+    log_device_discovery "root UUID from blkid(${source}): ${root_uuid}"
+    echo "$root_uuid"
+    return 0
+  fi
+
+  source="$(detect_root_partition "$mountpoint")" || return 1
+  root_uuid="$(blkid -s UUID -o value "$source" 2>/dev/null | head -n1 || true)"
+  if [ -n "$root_uuid" ]; then
+    log_device_discovery "root UUID from blkid(${source}): ${root_uuid}"
+    echo "$root_uuid"
+    return 0
+  fi
+
+  fail_device_discovery "unable to determine root UUID"
+}
+
+detect_swap_uuid() {
+  local swap_spec=""
+  local swap_dev=""
+  local swap_uuid=""
+
+  if [ -f /proc/swaps ]; then
+    swap_dev="$(awk 'NR>1 { print $1; exit }' /proc/swaps)"
+    if [ -n "$swap_dev" ]; then
+      swap_dev="$(resolve_device_spec "$swap_dev")"
+      swap_uuid="$(blkid -s UUID -o value "$swap_dev" 2>/dev/null | head -n1 || true)"
+      if [ -n "$swap_uuid" ]; then
+        log_device_discovery "swap UUID from /proc/swaps (${swap_dev}): ${swap_uuid}"
+        echo "$swap_uuid"
+        return 0
+      fi
+    fi
+  fi
+
+  if [ -f /etc/fstab ]; then
+    swap_spec="$(awk '$1 !~ /^#/ && $3 == "swap" { print $1; exit }' /etc/fstab)"
+    if [ -n "$swap_spec" ]; then
+      swap_dev="$(resolve_device_spec "$swap_spec")"
+      swap_uuid="$(blkid -s UUID -o value "$swap_dev" 2>/dev/null | head -n1 || true)"
+      if [ -n "$swap_uuid" ]; then
+        log_device_discovery "swap UUID from /etc/fstab (${swap_dev}): ${swap_uuid}"
+        echo "$swap_uuid"
+        return 0
+      fi
+    fi
+  fi
+
+  swap_dev="$(blkid -t TYPE=swap -o device 2>/dev/null | head -n1 || true)"
+  if [ -n "$swap_dev" ]; then
+    swap_uuid="$(blkid -s UUID -o value "$swap_dev" 2>/dev/null | head -n1 || true)"
+    if [ -n "$swap_uuid" ]; then
+      log_device_discovery "swap UUID from blkid scan (${swap_dev}): ${swap_uuid}"
+      echo "$swap_uuid"
+      return 0
+    fi
+  fi
+
+  log_device_discovery "swap UUID not found; returning explicit none"
+  echo "none"
+}


### PR DESCRIPTION
### Motivation
- Les scripts de la branche ventoyisation utilisaient des chemins de block devices codés en dur (ex: `/dev/nvme0n1p3`, `/dev/nvme0n1p4`) rendant le comportement fragile selon la topologie disque (NVMe/SATA/virtio/mmc). 
- L'objectif est de remplacer les références littérales par une détection dynamique et réutilisable pour root/swap afin d'améliorer la portabilité et la robustesse. 
- La portée couvre la suppression des références NVMe hardcodées dans les scripts runtime et l'introduction d'un helper commun pour centraliser la logique de découverte.

### Description
- Ajout du helper `live-injection-src/sysroot/ventoy/scripts/lib/device-discovery.sh` fournissant `detect_root_source`, `detect_root_partition`, `detect_root_uuid`, `detect_swap_uuid` et des fonctions de log/erreur. 
- Les fonctions implémentent une priorité de résolution basée sur `findmnt` → `/proc/cmdline` → `/etc/fstab` puis `blkid`/`/dev/disk` pour UUID/PARTUUID. 
- `configure-recovery-and-tpm.sh` a été modifié pour sourcer le helper et utiliser `detect_root_partition /` au lieu d’un `ROOT_PART` hardcodé. 
- `configure-btrfs-root-at.sh` a été modifié pour utiliser `detect_root_source /target`, `detect_root_uuid /target` et `detect_swap_uuid`, et inclut des validations bloquantes avec logs clairs si root/swap ne peuvent être résolus.

### Testing
- Recherches automatisées avec `rg -n "/dev/nvme0n1p3|/dev/nvme0n1p4|/dev/nvme" live-injection-src/sysroot/ventoy/scripts` ont confirmé l'absence de références hardcodées dans les scripts modifiés (succès). 
- Vérification de syntaxe shell avec `bash -n` sur `device-discovery.sh` et les scripts consommateurs modifiés a réussi (succès).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cede100360832ba1b46ed0fb17c744)