### PR TITLE
feat: restore encrypted swap + crypttab/initramfs resume flow (security parity with main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - NVMe only: /dev/nvme0n1
 - EFI 512MiB, Swap 32GiB (LUKS2), Root (LUKS2) + Btrfs subvolumes (@, @home, @var, @snapshots)
-- Hibernation: swap LUKS with persistent keyfile in initramfs
+- Hibernation: **supported with encrypted swap** (`cryptswap`) + initramfs resume mapping
 - TPM auto-unlock for root
 - Proxy nomade: active/désactive proxy selon IP 172.30/172.31
 - Factory mode: wipe only if /cdrom/NOLOUD/ARMED exists
@@ -12,6 +12,16 @@
 chmod +x scripts/*.sh
 ./scripts/build-iso.sh ubuntu-25.10-live-server-amd64.iso build/ubuntu-25.10-factory.iso
 ```
+
+## Chiffrement root/swap + reprise (resume)
+Le flux post-install configure explicitement:
+- `/etc/crypttab` pour `cryptroot` (UUID root LUKS détecté) et `cryptswap`.
+- keyfile persistant swap: `/etc/cryptsetup-keys.d/cryptswap.key`.
+- inclusion des keyfiles dans l'initramfs via `/etc/cryptsetup-initramfs/conf-hook`.
+- reprise hibernation via `/etc/initramfs-tools/conf.d/resume` (`RESUME=/dev/mapper/cryptswap`).
+- ligne swap `fstab` pointant vers `/dev/mapper/cryptswap`.
+
+Mode supporté: **hibernation chiffrée supportée** (swap LUKS dédié + resume initramfs).
 
 ## Proxy nomade
 Après install, un timer systemd applique ou retire le proxy automatiquement:

--- a/live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh
+++ b/live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh
@@ -3,7 +3,6 @@ set -euo pipefail
 
 exec > /target/root/configure-btrfs-root-at.log 2>&1
 
-
 log() {
   echo "[configure-btrfs-root-at] $*"
 }
@@ -33,7 +32,17 @@ EFI_DEV="$(findmnt -no SOURCE /target/boot/efi)"
 
 BOOT_UUID="$(blkid -s UUID -o value "$BOOT_DEV")"
 EFI_UUID="$(blkid -s UUID -o value "$EFI_DEV")"
-SWAP_UUID="$(blkid -s UUID -o value /dev/nvme0n1p3)"
+
+SWAP_FSTAB_ENTRY="/dev/mapper/cryptswap none swap sw 0 0"
+RESUME_DEV="/dev/mapper/cryptswap"
+if [ ! -e "$TARGET/dev/mapper/cryptswap" ]; then
+  SWAP_PART="$(blkid -t TYPE=swap -o device | head -n1 || true)"
+  if [ -n "$SWAP_PART" ]; then
+    SWAP_UUID="$(blkid -s UUID -o value "$SWAP_PART")"
+    SWAP_FSTAB_ENTRY="UUID=${SWAP_UUID} none swap sw 0 0"
+    RESUME_DEV="UUID=${SWAP_UUID}"
+  fi
+fi
 
 mkdir -p "$TOP"
 mount -o subvolid=5 "$ROOT_DEV" "$TOP"
@@ -73,22 +82,22 @@ if [ -d /target/var/cache ]; then
   rsync -aAXH --numeric-ids /target/var/cache/ "$TOP/@var_cache/" || true
 fi
 
-cat > "$TOP/@/etc/fstab" <<EOF
+cat > "$TOP/@/etc/fstab" <<EOF_FSTAB
 UUID=${BOOT_UUID} /boot ext4 defaults 0 1
 UUID=${EFI_UUID} /boot/efi vfat umask=0077 0 1
-UUID=${SWAP_UUID} none swap sw 0 0
+${SWAP_FSTAB_ENTRY}
 UUID=${ROOT_UUID} / btrfs subvol=@,compress=zstd,noatime,ssd,space_cache=v2 0 0
 UUID=${ROOT_UUID} /home btrfs subvol=@home,compress=zstd,noatime,ssd,space_cache=v2 0 0
 UUID=${ROOT_UUID} /var/log btrfs subvol=@var_log,compress=zstd,noatime,ssd,space_cache=v2 0 0
 UUID=${ROOT_UUID} /var/cache btrfs subvol=@var_cache,compress=zstd,noatime,ssd,space_cache=v2 0 0
 UUID=${ROOT_UUID} /.snapshots btrfs subvol=@snapshots,compress=zstd,noatime,ssd,space_cache=v2 0 0
-EOF
+EOF_FSTAB
 
+GRUB_CMDLINE='GRUB_CMDLINE_LINUX="rootflags=subvol=@ resume='"${RESUME_DEV}"'"'
 if grep -q '^GRUB_CMDLINE_LINUX=' "$TOP/@/etc/default/grub"; then
-  sed -i 's/^GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX="rootflags=subvol=@"/' \
-    "$TOP/@/etc/default/grub"
+  sed -i "s|^GRUB_CMDLINE_LINUX=.*|${GRUB_CMDLINE}|" "$TOP/@/etc/default/grub"
 else
-  echo 'GRUB_CMDLINE_LINUX="rootflags=subvol=@"' >> "$TOP/@/etc/default/grub"
+  echo "$GRUB_CMDLINE" >> "$TOP/@/etc/default/grub"
 fi
 
 mount --bind /dev  "$TOP/@/dev"

--- a/live-injection-src/sysroot/ventoy/scripts/configure-recovery-and-tpm.sh
+++ b/live-injection-src/sysroot/ventoy/scripts/configure-recovery-and-tpm.sh
@@ -1,14 +1,98 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-ROOT_PART="/dev/nvme0n1p4"
+log() {
+  echo "[configure-recovery-and-tpm] $*"
+}
+
+ensure_line_in_file() {
+  local file="$1"
+  local key="$2"
+  local line="$3"
+
+  touch "$file"
+  if grep -qE "^${key}[[:space:]]" "$file"; then
+    sed -i "s|^${key}[[:space:]].*|${line}|" "$file"
+  else
+    echo "$line" >> "$file"
+  fi
+}
+
+ROOT_MAPPER="$(findmnt -no SOURCE / || true)"
+ROOT_NAME="${ROOT_MAPPER#/dev/mapper/}"
+ROOT_PART=""
+
+if [ -n "$ROOT_NAME" ] && [ "$ROOT_NAME" != "$ROOT_MAPPER" ] && command -v cryptsetup >/dev/null 2>&1; then
+  ROOT_PART="$(cryptsetup status "$ROOT_NAME" 2>/dev/null | awk '/device:/ {print $2; exit}')"
+fi
+
+if [ -z "$ROOT_PART" ] || [ ! -b "$ROOT_PART" ]; then
+  log "WARNING: unable to detect root LUKS device, fallback to /dev/nvme0n1p4"
+  ROOT_PART="/dev/nvme0n1p4"
+fi
+
+ROOT_UUID="$(blkid -s UUID -o value "$ROOT_PART" 2>/dev/null || true)"
 
 install -d -m 0700 /root/recovery
 umask 077
-openssl rand -out /root/recovery/luks-root-recovery.key 32
+if [ ! -f /root/recovery/luks-root-recovery.key ]; then
+  openssl rand -out /root/recovery/luks-root-recovery.key 32
+fi
 
-cryptsetup luksAddKey "$ROOT_PART" /root/recovery/luks-root-recovery.key || true
+if [ -b "$ROOT_PART" ]; then
+  cryptsetup luksAddKey "$ROOT_PART" /root/recovery/luks-root-recovery.key || true
+fi
 
-if command -v systemd-cryptenroll >/dev/null 2>&1; then
+if command -v systemd-cryptenroll >/dev/null 2>&1 && [ -b "$ROOT_PART" ]; then
   systemd-cryptenroll --tpm2-device=auto "$ROOT_PART" || true
 fi
+
+if [ -n "$ROOT_UUID" ]; then
+  ensure_line_in_file /etc/crypttab cryptroot "cryptroot UUID=${ROOT_UUID} none luks,discard"
+fi
+
+install -d -m 0700 /etc/cryptsetup-keys.d
+SWAP_KEYFILE="/etc/cryptsetup-keys.d/cryptswap.key"
+if [ ! -f "$SWAP_KEYFILE" ]; then
+  openssl rand -out "$SWAP_KEYFILE" 64
+  chmod 0600 "$SWAP_KEYFILE"
+fi
+
+SWAP_PART="$(blkid -t TYPE=swap -o device | head -n1 || true)"
+if [ -z "$SWAP_PART" ] || [ ! -b "$SWAP_PART" ]; then
+  log "WARNING: no swap partition detected; encrypted hibernation will not be configured"
+  exit 0
+fi
+
+if ! cryptsetup isLuks "$SWAP_PART" >/dev/null 2>&1; then
+  swapoff -a || true
+  cryptsetup luksFormat --batch-mode "$SWAP_PART" "$SWAP_KEYFILE"
+fi
+
+if [ ! -b /dev/mapper/cryptswap ]; then
+  cryptsetup open "$SWAP_PART" cryptswap --key-file "$SWAP_KEYFILE"
+fi
+
+mkswap /dev/mapper/cryptswap
+swapon /dev/mapper/cryptswap || true
+
+SWAP_UUID="$(blkid -s UUID -o value "$SWAP_PART" 2>/dev/null || true)"
+if [ -n "$SWAP_UUID" ]; then
+  ensure_line_in_file /etc/crypttab cryptswap "cryptswap UUID=${SWAP_UUID} ${SWAP_KEYFILE} luks,discard"
+fi
+
+if grep -qE '^[^#].+[[:space:]]none[[:space:]]swap[[:space:]]' /etc/fstab; then
+  sed -i 's|^[^#].*[[:space:]]none[[:space:]]swap[[:space:]].*|/dev/mapper/cryptswap none swap sw 0 0|' /etc/fstab
+else
+  echo '/dev/mapper/cryptswap none swap sw 0 0' >> /etc/fstab
+fi
+
+cat > /etc/cryptsetup-initramfs/conf-hook <<'HOOK'
+KEYFILE_PATTERN="/etc/cryptsetup-keys.d/*.key"
+HOOK
+
+cat > /etc/initramfs-tools/conf.d/resume <<'RESUME'
+RESUME=/dev/mapper/cryptswap
+RESUME
+
+log "Configured cryptroot/cryptswap, initramfs key inclusion and resume mapping"

--- a/nocloud/user-data
+++ b/nocloud/user-data
@@ -28,6 +28,7 @@ autoinstall:
   packages:
     - btrfs-progs
     - cryptsetup
+    - cryptsetup-initramfs
     - openssh-server
 
   storage:
@@ -109,7 +110,7 @@ autoinstall:
     - curtin in-target -- bash /root/install-scripts/install-proxy-autoswitch.sh || true
 
     - curtin in-target -- apt-get update 
-    - curtin in-target -- apt-get install -y network-manager network-manager-openconnect iwd curl git wget ansible snapper tpm2-tools unattended-upgrades locales exfatprogs || true
+    - curtin in-target -- apt-get install -y network-manager network-manager-openconnect iwd curl git wget ansible snapper tpm2-tools unattended-upgrades locales exfatprogs cryptsetup-initramfs || true
 
     - curtin in-target -- bash /root/install-scripts/configure-networkmanager.sh
     - curtin in-target -- bash /root/install-scripts/configure-system-optimizations.sh


### PR DESCRIPTION
### Motivation
- Restore the previous security/functional model lost during the Ventoy refactor: dedicated encrypted swap, proper `crypttab` wiring, initramfs resume support and TPM/recovery coherence for root. 
- Provide an explicit, idempotent post-install flow so hibernation/unlock behaviors match the reference (main) setup.

### Description
- Add idempotent detection and wiring in `configure-recovery-and-tpm.sh`: detect root LUKS device (with fallback), generate/add a root recovery key, perform TPM enrollment when available, and ensure a `cryptroot` entry is present in `/etc/crypttab`.
- Implement encrypted swap handling in the same script: create `/etc/cryptsetup-keys.d/cryptswap.key`, detect or format the swap partition as LUKS, open/create `/dev/mapper/cryptswap`, enable swap, and add a `cryptswap` entry to `/etc/crypttab` and `/etc/fstab`.
- Ensure initramfs inclusion and resume mapping by creating `/etc/cryptsetup-initramfs/conf-hook` (keyfile pattern) and `/etc/initramfs-tools/conf.d/resume` (`RESUME=/dev/mapper/cryptswap`).
- Update `configure-btrfs-root-at.sh` to write a `fstab` compatible with `cryptswap`, set `GRUB_CMDLINE_LINUX` to include an explicit `resume=` (using `/dev/mapper/cryptswap` or the swap UUID), and regenerate `grub` and initramfs inside the target chroot.
- Add `cryptsetup-initramfs` to the autoinstall package lists and document the supported mode in `README.md` (explicit note that encrypted hibernation is supported and how the wiring works).

### Testing
- Syntax validation: `bash -n live-injection-src/sysroot/ventoy/scripts/configure-recovery-and-tpm.sh` passed without errors. 
- Syntax validation: `bash -n live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh` passed without errors. 
- Changes were inspected via diffs to confirm the expected `crypttab`, initramfs hook and `resume` wiring were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cedec49d40832ba20e00b2b062b3ce)