### PR TITLE
feat(autoinstall): install open-source Unicode and JetBrains fonts

### DIFF
--- a/nocloud/user-data
+++ b/nocloud/user-data
@@ -109,7 +109,7 @@ autoinstall:
     - curtin in-target -- bash /root/install-scripts/install-proxy-autoswitch.sh || true
 
     - curtin in-target -- apt-get update 
-    - curtin in-target -- apt-get install -y network-manager network-manager-openconnect iwd curl git wget ansible snapper tpm2-tools unattended-upgrades locales exfatprogs || true
+    - curtin in-target -- apt-get install -y network-manager network-manager-openconnect iwd curl git wget ansible snapper tpm2-tools unattended-upgrades locales exfatprogs fonts-noto-core fonts-noto-color-emoji fonts-jetbrains-mono fonts-unifont || true
 
     - curtin in-target -- bash /root/install-scripts/configure-networkmanager.sh
     - curtin in-target -- bash /root/install-scripts/configure-system-optimizations.sh


### PR DESCRIPTION
### Motivation
- Ensure the installed machine has broad Unicode coverage and JetBrains Mono available out-of-the-box by adding common open-source font packages to the autoinstall package list.

### Description
- Updated `nocloud/user-data` to add `fonts-noto-core`, `fonts-noto-color-emoji`, `fonts-unifont`, and `fonts-jetbrains-mono` to the `apt-get install` step in the autoinstall `late-commands`.

### Testing
- Ran `git diff -- nocloud/user-data` and inspected `nl -ba nocloud/user-data | sed -n '100,122p'` to verify the package line was updated, and committed the change with `git commit`; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cedf670d10832ba7b35ddacf504e46)