### PR TITLE
PR3 feat: restore encrypted swap + crypttab/initramfs resume flow (security parity with main)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - NVMe only: /dev/nvme0n1
 - EFI 512MiB, Swap 32GiB (LUKS2), Root (LUKS2) + Btrfs subvolumes (@, @home, @var, @snapshots)
-- Hibernation: swap LUKS with persistent keyfile in initramfs
+- Hibernation: swap LUKS (`cryptswap`) with persistent keyfile included in initramfs + `resume=/dev/mapper/cryptswap`
 - TPM auto-unlock for root
 - Proxy nomade: active/désactive proxy selon IP 172.30/172.31
 - Factory mode: wipe only if /cdrom/NOLOUD/ARMED exists
@@ -18,3 +18,10 @@ Après install, un timer systemd applique ou retire le proxy automatiquement:
 - /etc/proxy-autoswitch.conf
 - /usr/local/sbin/proxy-autoswitch
 - systemd: proxy-autoswitch.timer
+
+## Chiffrement root/swap (parité sécurité)
+- `/etc/crypttab` est régénéré pour inclure:
+  - `cryptroot` (UUID root LUKS + option TPM2)
+  - `cryptswap` (UUID swap LUKS + keyfile persistant)
+- keyfile swap: `/etc/cryptsetup-keys.d/cryptswap.key` (copié dans initramfs via `KEYFILE_PATTERN`)
+- reprise hibernation: `/etc/initramfs-tools/conf.d/resume` pointe vers `/dev/mapper/cryptswap`

--- a/live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh
+++ b/live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh
@@ -27,16 +27,18 @@ run_critical_step() {
 
 TARGET="/target"
 TOP="/mnt/btrfs-top"
+CRYPTSWAP_NAME="cryptswap"
+CRYPTSWAP_KEYFILE="/etc/cryptsetup-keys.d/cryptswap.key"
 
 ROOT_DEV="$(detect_root_source /target)"
 ROOT_UUID="$(detect_root_uuid /target)"
+SWAP_PART="$(extract_swap_device_from_fstab /target/etc/fstab)"
 
 BOOT_DEV="$(findmnt -no SOURCE /target/boot)"
 EFI_DEV="$(findmnt -no SOURCE /target/boot/efi)"
 
 BOOT_UUID="$(blkid -s UUID -o value "$BOOT_DEV")"
 EFI_UUID="$(blkid -s UUID -o value "$EFI_DEV")"
-SWAP_UUID="$(detect_swap_uuid)"
 
 if [ -z "$ROOT_DEV" ] || [ ! -e "$ROOT_DEV" ]; then
   fail_device_discovery "unable to resolve root device for /target"
@@ -48,13 +50,38 @@ if [ -z "$ROOT_UUID" ]; then
   exit 1
 fi
 
-if [ "$SWAP_UUID" = "none" ] || [ -z "$SWAP_UUID" ]; then
-  fail_device_discovery "unable to resolve swap UUID; refusing to generate fstab"
+if [ -z "$SWAP_PART" ] || [ ! -b "$SWAP_PART" ]; then
+  fail_device_discovery "unable to resolve swap partition from /target/etc/fstab"
   exit 1
 fi
 
 mkdir -p "$TOP"
 mount -o subvolid=5 "$ROOT_DEV" "$TOP"
+
+install -d -m 0700 "$TOP/@/etc/cryptsetup-keys.d"
+if [ ! -f "$TOP/@${CRYPTSWAP_KEYFILE}" ]; then
+  umask 0077
+  dd if=/dev/urandom of="$TOP/@${CRYPTSWAP_KEYFILE}" bs=64 count=1 status=none
+fi
+
+SWAP_TYPE="$(blkid -s TYPE -o value "$SWAP_PART" 2>/dev/null || true)"
+if [ "$SWAP_TYPE" != "crypto_LUKS" ]; then
+  log "Formatting swap partition with LUKS2: $SWAP_PART"
+  cryptsetup luksFormat --type luks2 --batch-mode "$SWAP_PART" "$TOP/@${CRYPTSWAP_KEYFILE}"
+fi
+
+if [ ! -e "/dev/mapper/${CRYPTSWAP_NAME}" ]; then
+  cryptsetup open "$SWAP_PART" "$CRYPTSWAP_NAME" --key-file "$TOP/@${CRYPTSWAP_KEYFILE}"
+fi
+
+mkswap "/dev/mapper/${CRYPTSWAP_NAME}" >/dev/null
+SWAP_UUID="$(blkid -s UUID -o value "/dev/mapper/${CRYPTSWAP_NAME}")"
+SWAP_LUKS_UUID="$(blkid -s UUID -o value "$SWAP_PART")"
+
+if [ -z "$SWAP_UUID" ] || [ -z "$SWAP_LUKS_UUID" ]; then
+  fail_device_discovery "unable to resolve encrypted swap identifiers"
+  exit 1
+fi
 
 for sv in @ @home @var_log @var_cache @snapshots; do
   if ! btrfs subvolume show "$TOP/$sv" >/dev/null 2>&1; then
@@ -94,7 +121,7 @@ fi
 cat > "$TOP/@/etc/fstab" <<EOF
 UUID=${BOOT_UUID} /boot ext4 defaults 0 1
 UUID=${EFI_UUID} /boot/efi vfat umask=0077 0 1
-UUID=${SWAP_UUID} none swap sw 0 0
+/dev/mapper/${CRYPTSWAP_NAME} none swap sw 0 0
 UUID=${ROOT_UUID} / btrfs subvol=@,compress=zstd,noatime,ssd,space_cache=v2 0 0
 UUID=${ROOT_UUID} /home btrfs subvol=@home,compress=zstd,noatime,ssd,space_cache=v2 0 0
 UUID=${ROOT_UUID} /var/log btrfs subvol=@var_log,compress=zstd,noatime,ssd,space_cache=v2 0 0
@@ -102,11 +129,36 @@ UUID=${ROOT_UUID} /var/cache btrfs subvol=@var_cache,compress=zstd,noatime,ssd,s
 UUID=${ROOT_UUID} /.snapshots btrfs subvol=@snapshots,compress=zstd,noatime,ssd,space_cache=v2 0 0
 EOF
 
+cat > "$TOP/@/etc/crypttab" <<EOF
+cryptroot UUID=${ROOT_UUID} none luks,discard,tpm2-device=auto
+${CRYPTSWAP_NAME} UUID=${SWAP_LUKS_UUID} ${CRYPTSWAP_KEYFILE} luks,discard
+EOF
+
+install -d -m 0755 "$TOP/@/etc/initramfs-tools/conf.d"
+cat > "$TOP/@/etc/initramfs-tools/conf.d/resume" <<EOF
+RESUME=/dev/mapper/${CRYPTSWAP_NAME}
+EOF
+
+install -d -m 0755 "$TOP/@/etc/cryptsetup-initramfs"
+if [ -f "$TOP/@/etc/cryptsetup-initramfs/conf-hook" ]; then
+  if grep -q '^KEYFILE_PATTERN=' "$TOP/@/etc/cryptsetup-initramfs/conf-hook"; then
+    sed -i 's|^KEYFILE_PATTERN=.*|KEYFILE_PATTERN="/etc/cryptsetup-keys.d/*.key"|' \
+      "$TOP/@/etc/cryptsetup-initramfs/conf-hook"
+  else
+    echo 'KEYFILE_PATTERN="/etc/cryptsetup-keys.d/*.key"' >> "$TOP/@/etc/cryptsetup-initramfs/conf-hook"
+  fi
+else
+  cat > "$TOP/@/etc/cryptsetup-initramfs/conf-hook" <<EOF
+KEYFILE_PATTERN="/etc/cryptsetup-keys.d/*.key"
+EOF
+fi
+
+GRUB_LINUX_ARGS="rootflags=subvol=@ resume=/dev/mapper/${CRYPTSWAP_NAME}"
 if grep -q '^GRUB_CMDLINE_LINUX=' "$TOP/@/etc/default/grub"; then
-  sed -i 's/^GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX="rootflags=subvol=@"/' \
+  sed -i "s|^GRUB_CMDLINE_LINUX=.*|GRUB_CMDLINE_LINUX=\"${GRUB_LINUX_ARGS}\"|" \
     "$TOP/@/etc/default/grub"
 else
-  echo 'GRUB_CMDLINE_LINUX="rootflags=subvol=@"' >> "$TOP/@/etc/default/grub"
+  echo "GRUB_CMDLINE_LINUX=\"${GRUB_LINUX_ARGS}\"" >> "$TOP/@/etc/default/grub"
 fi
 
 mount --bind /dev  "$TOP/@/dev"
@@ -119,6 +171,7 @@ run_critical_step "update-initramfs -u -k all" chroot "$TOP/@" update-initramfs 
 umount "$TOP/@/dev" || true
 umount "$TOP/@/proc" || true
 umount "$TOP/@/sys" || true
+cryptsetup close "${CRYPTSWAP_NAME}" || true
 umount "$TOP"
 
 sync

--- a/live-injection-src/sysroot/ventoy/scripts/lib/device-discovery.sh
+++ b/live-injection-src/sysroot/ventoy/scripts/lib/device-discovery.sh
@@ -162,3 +162,22 @@ detect_swap_uuid() {
   log_device_discovery "swap UUID not found; returning explicit none"
   echo "none"
 }
+
+extract_swap_device_from_fstab() {
+  local fstab_path="${1:-/etc/fstab}"
+  local swap_spec=""
+  local swap_dev=""
+
+  [ -f "$fstab_path" ] || return 0
+
+  swap_spec="$(awk '$1 !~ /^#/ && $3 == "swap" { print $1; exit }' "$fstab_path")"
+  if [ -z "$swap_spec" ]; then
+    return 0
+  fi
+
+  swap_dev="$(resolve_device_spec "$swap_spec")"
+  if [ -n "$swap_dev" ]; then
+    log_device_discovery "swap device from ${fstab_path} (${swap_spec}): ${swap_dev}"
+    echo "$swap_dev"
+  fi
+}


### PR DESCRIPTION
### Motivation
- La refonte Ventoy avait éliminé des éléments du flux de chiffrement précédent (swap chiffré dédié, câblage `crypttab`, reprise via initramfs et cohérence TPM/recovery) ce qui risque de casser l’hibernation chiffrée et l’unlock au boot.
- L’objectif est de rétablir une parité fonctionnelle et de sécurité avec la branche `main` pour le flux `cryptroot`/`cryptswap`/`resume` de manière explicite et testable.

### Description
- Ajout d’un helper `extract_swap_device_from_fstab()` dans `live-injection-src/sysroot/ventoy/scripts/lib/device-discovery.sh` pour extraire proprement la partition swap depuis un `fstab` cible.
- Restauration du flux swap chiffré dans `live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh` avec génération d’un keyfile persistant (`/etc/cryptsetup-keys.d/cryptswap.key`), formatage LUKS2 si nécessaire, ouverture `cryptsetup` du `cryptswap`, et `mkswap` sur le mapper chiffré.
- Génération et écriture de la configuration attendue côté système installé: `/etc/fstab` (swap via `/dev/mapper/cryptswap`), `/etc/crypttab` (entrées `cryptroot` + `cryptswap`), et fichier `initramfs-tools/conf.d/resume` pointant vers `/dev/mapper/cryptswap`.
- Mise à jour de `KEYFILE_PATTERN` dans `cryptsetup-initramfs` pour inclure la clé swap dans l’initramfs et propagation de `resume=/dev/mapper/cryptswap` dans les arguments GRUB, plus fermeture propre du mapper avant la fin du script.
- Documentation mise à jour dans `README.md` pour préciser le support de l’hibernation chiffrée et les artefacts (`crypttab`, keyfile, resume).

### Testing
- Vérification de la syntaxe shell via `bash -n live-injection-src/sysroot/ventoy/scripts/lib/device-discovery.sh live-injection-src/sysroot/ventoy/scripts/configure-btrfs-root-at.sh live-injection-src/sysroot/ventoy/scripts/configure-recovery-and-tpm.sh`, qui a réussi sans erreurs.
- Aucun test automatique d’intégration (chroot/update-initramfs/update-grub/boot/hibernation) n’a été exécuté dans cet environnement; ces scénarios sont décrits dans le plan de test et doivent être validés en VM avant merge.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cf925e378c832bb105c921fe2cca1e)