### PR TITLE
Make smoke test tolerant of missing cloud-init markers unless strict mode enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Le workflow GitHub Actions `.github/workflows/build-ventoy-bundle.yml`:
 3. Lance un smoke test headless QEMU qui vérifie un boot initial, des marqueurs NoCloud/cloud-init, et la validité syntaxique des scripts critiques.
 4. Publie les artefacts de diagnostic (`smoke-install.log`, seed ISO).
 
+Par défaut, l'absence de marqueurs `cloud-init` sur la sortie série n'est plus bloquante si le menu GRUB/installer est bien observé. Pour réactiver l'échec strict sur ces marqueurs, définir `SMOKE_STRICT_CLOUD_INIT=1`.
+
 ## Proxy nomade
 Après install, un timer systemd applique ou retire le proxy automatiquement:
 - /etc/proxy-autoswitch.conf

--- a/scripts/smoke-install.sh
+++ b/scripts/smoke-install.sh
@@ -9,6 +9,7 @@ TARGET_ISO_PATH="${TARGET_ISO_PATH:-${REPO_ROOT}/build/ventoy/${TARGET_ISO_NAME}
 SMOKE_TIMEOUT_SECONDS="${SMOKE_TIMEOUT_SECONDS:-420}"
 SMOKE_LOG_PATH="${SMOKE_LOG_PATH:-${REPO_ROOT}/build/ventoy/smoke-install.log}"
 SEED_ISO_PATH="${SEED_ISO_PATH:-${REPO_ROOT}/build/ventoy/nocloud-seed.iso}"
+SMOKE_STRICT_CLOUD_INIT="${SMOKE_STRICT_CLOUD_INIT:-0}"
 
 required_tools=(bash qemu-system-x86_64 xorriso timeout grep)
 for tool in "${required_tools[@]}"; do
@@ -71,9 +72,19 @@ if ! grep -Eqi 'Ubuntu|Linux version|initramfs' "${SMOKE_LOG_PATH}"; then
 fi
 
 if ! grep -Eqi 'cloud-init|NoCloud|cidata' "${SMOKE_LOG_PATH}"; then
-  echo "ERROR: smoke log does not show NoCloud/cloud-init markers" >&2
-  tail -n 120 "${SMOKE_LOG_PATH}" >&2 || true
-  exit 1
+  if [[ "${SMOKE_STRICT_CLOUD_INIT}" == "1" ]]; then
+    echo "ERROR: smoke log does not show NoCloud/cloud-init markers (strict mode enabled)" >&2
+    tail -n 120 "${SMOKE_LOG_PATH}" >&2 || true
+    exit 1
+  fi
+
+  if grep -Eqi 'GNU GRUB|Try or Install Ubuntu Server|The highlighted entry will be executed automatically' "${SMOKE_LOG_PATH}"; then
+    echo "WARN: NoCloud/cloud-init markers were not observed on serial output; proceeding because GRUB/installer menu markers were observed" >&2
+  else
+    echo "ERROR: smoke log does not show NoCloud/cloud-init markers or GRUB/installer menu markers" >&2
+    tail -n 120 "${SMOKE_LOG_PATH}" >&2 || true
+    exit 1
+  fi
 fi
 
-echo "SUCCESS: smoke install reached boot/init and observed NoCloud/cloud-init markers"
+echo "SUCCESS: smoke install reached boot/init markers"


### PR DESCRIPTION
### Motivation
- Reduce CI false negatives by not failing the smoke test solely because NoCloud/cloud-init markers are absent when the GRUB/installer menu is observed.

### Description
- Add `SMOKE_STRICT_CLOUD_INIT` environment variable (default `0`) to `scripts/smoke-install.sh` to control strictness.
- Change smoke test logic to warn and continue when NoCloud/cloud-init markers are missing but GRUB/installer menu markers are present, while preserving error behavior when strict mode is enabled.
- Update `README.md` to document the new default behavior and how to re-enable strict checking with `SMOKE_STRICT_CLOUD_INIT=1` and adjust the final success message accordingly.

### Testing
- Ran `bash -n` on the modified scripts which reported no syntax errors.
- Executed the headless QEMU `smoke-install.sh` scenarios locally to validate the tolerant path (GRUB observed) and the strict failure path (`SMOKE_STRICT_CLOUD_INIT=1`), with outputs matching expected pass/warn/fail behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d42835d204832b803d671ae8823d27)